### PR TITLE
Center report typography and add video posters

### DIFF
--- a/assets/poster_leak_stop.svg
+++ b/assets/poster_leak_stop.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720">
+  <defs>
+    <linearGradient id="leakGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00BED6" />
+      <stop offset="100%" stop-color="#006F9A" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.65" />
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="720" fill="url(#leakGradient)" rx="48" />
+  <rect width="1280" height="360" fill="url(#shine)" />
+  <g fill="none" stroke="#FFFFFF" stroke-opacity="0.35" stroke-width="4">
+    <circle cx="1080" cy="140" r="90" />
+    <circle cx="120" cy="600" r="70" />
+    <path d="M160 180 l60 -60" />
+    <path d="M1120 580 l80 -80" />
+  </g>
+  <g fill="#FFFFFF" text-anchor="middle" font-family="'Noto Sans TC', 'PingFang TC', sans-serif">
+    <text x="640" y="320" font-size="72" font-weight="700">全屋漏水不用怕！</text>
+    <text x="640" y="400" font-size="48" font-weight="600">1 秒自動斷水防災裝置</text>
+    <text x="640" y="470" font-size="32" font-weight="500" opacity="0.85">點擊播放影片了解守護方法</text>
+  </g>
+  <g transform="translate(640 520)">
+    <circle r="78" fill="rgba(255, 255, 255, 0.25)" />
+    <circle r="66" fill="rgba(255, 255, 255, 0.45)" />
+    <polygon points="-18,-28 32,0 -18,28" fill="#FFFFFF" />
+  </g>
+</svg>

--- a/assets/poster_restore_water.svg
+++ b/assets/poster_restore_water.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720">
+  <defs>
+    <linearGradient id="restoreGradient" x1="100%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#4C9EFF" />
+      <stop offset="100%" stop-color="#123D8B" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1280" height="720" fill="url(#restoreGradient)" rx="48" />
+  <rect width="1280" height="720" fill="url(#glow)" />
+  <g opacity="0.25" stroke="#FFFFFF" stroke-width="6" stroke-linecap="round">
+    <path d="M160 520 q160 -220 360 -40" fill="none" />
+    <path d="M1160 180 q-200 260 -420 80" fill="none" />
+    <circle cx="260" cy="220" r="60" fill="none" />
+    <circle cx="1010" cy="540" r="80" fill="none" />
+  </g>
+  <g fill="#FFFFFF" text-anchor="middle" font-family="'Noto Sans TC', 'PingFang TC', sans-serif">
+    <text x="640" y="320" font-size="70" font-weight="700">家裡突然斷水？</text>
+    <text x="640" y="395" font-size="48" font-weight="600">3 步立刻恢復用水教學</text>
+    <text x="640" y="468" font-size="32" font-weight="500" opacity="0.85">跟著影片一步步排查</text>
+  </g>
+  <g transform="translate(640 525)">
+    <circle r="78" fill="rgba(255, 255, 255, 0.2)" />
+    <circle r="66" fill="rgba(255, 255, 255, 0.4)" />
+    <polygon points="-18,-28 32,0 -18,28" fill="#FFFFFF" />
+  </g>
+</svg>

--- a/report.html
+++ b/report.html
@@ -30,7 +30,7 @@
     <div class="videos-section">
       <!-- 第一個影片：顯示自動斷水裝置介紹 -->
       <div class="video-item">
-        <video controls playsinline preload="metadata">
+        <video controls playsinline preload="metadata" poster="assets/poster_leak_stop.svg">
           <source src="assets/1252_1757912418.mp4" type="video/mp4">
         </video>
         <!-- 標題覆蓋於影片預覽，簡要描述影片內容，吸引用戶點擊 -->
@@ -39,7 +39,7 @@
       </div>
       <!-- 第二個影片：顯示如何快速恢復用水 -->
       <div class="video-item">
-        <video controls playsinline preload="metadata">
+        <video controls playsinline preload="metadata" poster="assets/poster_restore_water.svg">
           <source src="assets/1253_1757912439.mp4" type="video/mp4">
         </video>
         <div class="caption">家裡突然斷水？3步立刻搞定</div>

--- a/style.css
+++ b/style.css
@@ -969,3 +969,80 @@ button:hover {
 .referral-wrapper .share-btn {
   margin-top: 16px;
 }
+
+/* ------------------------------------------------------------------ */
+/* Final layout refinements for centred typography and spacing       */
+/* ------------------------------------------------------------------ */
+main.container {
+  text-align: center;
+  padding: 28px 24px 48px;
+}
+
+main.container > * + * {
+  margin-top: 24px;
+}
+
+.intro-card {
+  padding: 28px 24px;
+  text-align: center;
+  margin-top: -32px;
+  box-shadow: 0 6px 16px rgba(11, 24, 33, 0.08);
+}
+
+.intro-card .greeting-text p {
+  margin-bottom: 12px;
+}
+
+.intro-card .btn {
+  margin-top: 20px;
+}
+
+#slidesContainer {
+  margin: 0 auto;
+}
+
+#slidesContainer p {
+  margin: 0;
+}
+
+.slides-wrapper {
+  margin-left: auto;
+  margin-right: auto;
+  padding: 8px 0 4px;
+}
+
+.next-date-text {
+  margin: 0;
+}
+
+.btn {
+  margin: 0 auto;
+}
+
+.videos-section {
+  margin-left: auto;
+  margin-right: auto;
+  gap: 20px;
+}
+
+.videos-section .video-item {
+  box-shadow: 0 6px 16px rgba(11, 24, 33, 0.08);
+}
+
+.videos-section .play-overlay {
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.services-wrapper,
+.referral-wrapper {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.referral-wrapper {
+  padding: 20px 16px 28px;
+}
+
+.referral-wrapper .share-btn {
+  margin-top: 20px;
+}


### PR DESCRIPTION
## Summary
- center the report layout and add consistent spacing so the sections breathe more comfortably
- adjust video card styling and overlay tint to keep the thumbnails visible
- provide dedicated poster artwork for each video so that mobile devices display a cover image

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68c8c1250eb08328b4024cf95d0952bd