### PR TITLE
Soften video overlays and widen report spacing

### DIFF
--- a/assets/poster_leak_stop.svg
+++ b/assets/poster_leak_stop.svg
@@ -1,30 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720">
   <defs>
-    <linearGradient id="leakGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#00BED6" />
-      <stop offset="100%" stop-color="#00BED6" />
-    </linearGradient>
-    <linearGradient id="shine" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.65" />
-      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0" />
-    </linearGradient>
+    <clipPath id="rounded">
+      <rect width="1280" height="720" rx="48" />
+    </clipPath>
   </defs>
-  <rect width="1280" height="720" fill="url(#leakGradient)" rx="48" />
-  <rect width="1280" height="360" fill="url(#shine)" />
-  <g fill="none" stroke="#FFFFFF" stroke-opacity="0.35" stroke-width="4">
-    <circle cx="1080" cy="140" r="90" />
-    <circle cx="120" cy="600" r="70" />
-    <path d="M160 180 l60 -60" />
-    <path d="M1120 580 l80 -80" />
+  <g clip-path="url(#rounded)">
+    <rect width="1280" height="720" fill="#00BED6" />
+    <path d="M0 440C220 340 430 280 640 280s420 60 640 160v280H0z" fill="#009FBE" opacity="0.45" />
+    <path d="M0 300C240 360 430 420 640 420s400-40 640-140V0H0z" fill="#2DD8EB" opacity="0.18" />
+    <circle cx="1080" cy="140" r="88" fill="none" stroke="rgba(255, 255, 255, 0.5)" stroke-width="4" />
+    <circle cx="160" cy="560" r="72" fill="none" stroke="rgba(255, 255, 255, 0.35)" stroke-width="4" />
+    <path d="M180 220l70-70M1090 600l80-80" stroke="#FFFFFF" stroke-opacity="0.4" stroke-width="6" stroke-linecap="round" />
+    <rect width="1280" height="320" fill="#FFFFFF" opacity="0.12" />
   </g>
-  <g fill="#FFFFFF" text-anchor="middle" font-family="'Noto Sans TC', 'PingFang TC', sans-serif">
-    <text x="640" y="320" font-size="72" font-weight="700">全屋漏水不用怕！</text>
-    <text x="640" y="400" font-size="48" font-weight="600">1 秒自動斷水防災裝置</text>
-    <text x="640" y="470" font-size="32" font-weight="500" opacity="0.85">點擊播放影片了解守護方法</text>
+  <g fill="#FFFFFF" text-anchor="middle" font-family="'Noto Sans TC', 'PingFang TC', 'Microsoft JhengHei', sans-serif">
+    <text x="640" y="312" font-size="72" font-weight="700">全屋漏水不用怕！</text>
+    <text x="640" y="392" font-size="48" font-weight="600">1 秒自動斷水防災裝置</text>
+    <text x="640" y="460" font-size="32" font-weight="500" opacity="0.85">點擊播放影片了解守護方法</text>
   </g>
-  <g transform="translate(640 520)">
-    <circle r="78" fill="rgba(255, 255, 255, 0.25)" />
+  <g transform="translate(640 530)">
+    <circle r="78" fill="rgba(255, 255, 255, 0.22)" />
     <circle r="66" fill="rgba(255, 255, 255, 0.45)" />
-    <polygon points="-18,-28 32,0 -18,28" fill="#FFFFFF" />
+    <polygon points="-18,-28 32,0 -18,28" fill="#0A4A57" />
   </g>
 </svg>

--- a/assets/poster_leak_stop.svg
+++ b/assets/poster_leak_stop.svg
@@ -13,14 +13,9 @@
     <path d="M180 220l70-70M1090 600l80-80" stroke="#FFFFFF" stroke-opacity="0.4" stroke-width="6" stroke-linecap="round" />
     <rect width="1280" height="320" fill="#FFFFFF" opacity="0.12" />
   </g>
-  <g fill="#FFFFFF" text-anchor="middle" font-family="'Noto Sans TC', 'PingFang TC', 'Microsoft JhengHei', sans-serif">
-    <text x="640" y="312" font-size="72" font-weight="700">全屋漏水不用怕！</text>
-    <text x="640" y="392" font-size="48" font-weight="600">1 秒自動斷水防災裝置</text>
-    <text x="640" y="460" font-size="32" font-weight="500" opacity="0.85">點擊播放影片了解守護方法</text>
-  </g>
-  <g transform="translate(640 530)">
-    <circle r="78" fill="rgba(255, 255, 255, 0.22)" />
-    <circle r="66" fill="rgba(255, 255, 255, 0.45)" />
-    <polygon points="-18,-28 32,0 -18,28" fill="#0A4A57" />
+  <g fill="#FFFFFF" font-family="'Noto Sans TC', 'PingFang TC', 'Microsoft JhengHei', sans-serif">
+    <text x="136" y="286" font-size="68" font-weight="700">全屋漏水不用怕！</text>
+    <text x="136" y="366" font-size="48" font-weight="600">1 秒自動斷水防災裝置</text>
+    <text x="136" y="440" font-size="32" font-weight="500" opacity="0.85">點擊播放影片了解守護方法</text>
   </g>
 </svg>

--- a/assets/poster_leak_stop.svg
+++ b/assets/poster_leak_stop.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720">
+  <defs>
+    <linearGradient id="leakGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00BED6" />
+      <stop offset="100%" stop-color="#00BED6" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.65" />
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="720" fill="url(#leakGradient)" rx="48" />
+  <rect width="1280" height="360" fill="url(#shine)" />
+  <g fill="none" stroke="#FFFFFF" stroke-opacity="0.35" stroke-width="4">
+    <circle cx="1080" cy="140" r="90" />
+    <circle cx="120" cy="600" r="70" />
+    <path d="M160 180 l60 -60" />
+    <path d="M1120 580 l80 -80" />
+  </g>
+  <g fill="#FFFFFF" text-anchor="middle" font-family="'Noto Sans TC', 'PingFang TC', sans-serif">
+    <text x="640" y="320" font-size="72" font-weight="700">全屋漏水不用怕！</text>
+    <text x="640" y="400" font-size="48" font-weight="600">1 秒自動斷水防災裝置</text>
+    <text x="640" y="470" font-size="32" font-weight="500" opacity="0.85">點擊播放影片了解守護方法</text>
+  </g>
+  <g transform="translate(640 520)">
+    <circle r="78" fill="rgba(255, 255, 255, 0.25)" />
+    <circle r="66" fill="rgba(255, 255, 255, 0.45)" />
+    <polygon points="-18,-28 32,0 -18,28" fill="#FFFFFF" />
+  </g>
+</svg>

--- a/assets/poster_restore_water.svg
+++ b/assets/poster_restore_water.svg
@@ -1,30 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720">
   <defs>
-    <linearGradient id="restoreGradient" x1="100%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#00BED6" />
-      <stop offset="100%" stop-color="#00BED6" />
-    </linearGradient>
-    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
-      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.6" />
-      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0" />
-    </radialGradient>
+    <clipPath id="rounded">
+      <rect width="1280" height="720" rx="48" />
+    </clipPath>
   </defs>
-  <rect width="1280" height="720" fill="url(#restoreGradient)" rx="48" />
-  <rect width="1280" height="720" fill="url(#glow)" />
-  <g opacity="0.25" stroke="#FFFFFF" stroke-width="6" stroke-linecap="round">
-    <path d="M160 520 q160 -220 360 -40" fill="none" />
-    <path d="M1160 180 q-200 260 -420 80" fill="none" />
-    <circle cx="260" cy="220" r="60" fill="none" />
-    <circle cx="1010" cy="540" r="80" fill="none" />
+  <g clip-path="url(#rounded)">
+    <rect width="1280" height="720" fill="#00BED6" />
+    <path d="M0 520c210-80 420-120 640-120s430 40 640 120v200H0z" fill="#009FBE" opacity="0.42" />
+    <path d="M0 0h1280v260C1050 200 840 160 640 160S240 200 0 300z" fill="#2DD8EB" opacity="0.2" />
+    <circle cx="1040" cy="170" r="76" fill="none" stroke="rgba(255, 255, 255, 0.45)" stroke-width="4" />
+    <circle cx="220" cy="570" r="64" fill="none" stroke="rgba(255, 255, 255, 0.35)" stroke-width="4" />
+    <path d="M220 210l64-64M1060 560l74-74" stroke="#FFFFFF" stroke-opacity="0.4" stroke-width="6" stroke-linecap="round" />
+    <rect width="1280" height="320" fill="#FFFFFF" opacity="0.12" />
   </g>
-  <g fill="#FFFFFF" text-anchor="middle" font-family="'Noto Sans TC', 'PingFang TC', sans-serif">
-    <text x="640" y="320" font-size="70" font-weight="700">家裡突然斷水？</text>
-    <text x="640" y="395" font-size="48" font-weight="600">3 步立刻恢復用水教學</text>
-    <text x="640" y="468" font-size="32" font-weight="500" opacity="0.85">跟著影片一步步排查</text>
+  <g fill="#FFFFFF" text-anchor="middle" font-family="'Noto Sans TC', 'PingFang TC', 'Microsoft JhengHei', sans-serif">
+    <text x="640" y="312" font-size="72" font-weight="700">家裡突然斷水？</text>
+    <text x="640" y="392" font-size="48" font-weight="600">教你 3 步快速恢復用水</text>
+    <text x="640" y="460" font-size="32" font-weight="500" opacity="0.85">先看影片，遇到狀況就不慌</text>
   </g>
-  <g transform="translate(640 525)">
-    <circle r="78" fill="rgba(255, 255, 255, 0.2)" />
-    <circle r="66" fill="rgba(255, 255, 255, 0.4)" />
-    <polygon points="-18,-28 32,0 -18,28" fill="#FFFFFF" />
+  <g transform="translate(640 530)">
+    <circle r="78" fill="rgba(255, 255, 255, 0.22)" />
+    <circle r="66" fill="rgba(255, 255, 255, 0.45)" />
+    <polygon points="-18,-28 32,0 -18,28" fill="#0A4A57" />
   </g>
 </svg>

--- a/assets/poster_restore_water.svg
+++ b/assets/poster_restore_water.svg
@@ -13,14 +13,9 @@
     <path d="M220 210l64-64M1060 560l74-74" stroke="#FFFFFF" stroke-opacity="0.4" stroke-width="6" stroke-linecap="round" />
     <rect width="1280" height="320" fill="#FFFFFF" opacity="0.12" />
   </g>
-  <g fill="#FFFFFF" text-anchor="middle" font-family="'Noto Sans TC', 'PingFang TC', 'Microsoft JhengHei', sans-serif">
-    <text x="640" y="312" font-size="72" font-weight="700">家裡突然斷水？</text>
-    <text x="640" y="392" font-size="48" font-weight="600">教你 3 步快速恢復用水</text>
-    <text x="640" y="460" font-size="32" font-weight="500" opacity="0.85">先看影片，遇到狀況就不慌</text>
-  </g>
-  <g transform="translate(640 530)">
-    <circle r="78" fill="rgba(255, 255, 255, 0.22)" />
-    <circle r="66" fill="rgba(255, 255, 255, 0.45)" />
-    <polygon points="-18,-28 32,0 -18,28" fill="#0A4A57" />
+  <g fill="#FFFFFF" font-family="'Noto Sans TC', 'PingFang TC', 'Microsoft JhengHei', sans-serif">
+    <text x="140" y="286" font-size="68" font-weight="700">家裡突然斷水？</text>
+    <text x="140" y="366" font-size="48" font-weight="600">教你 3 步快速恢復用水</text>
+    <text x="140" y="440" font-size="32" font-weight="500" opacity="0.85">先看影片，遇到狀況就不慌</text>
   </g>
 </svg>

--- a/assets/poster_restore_water.svg
+++ b/assets/poster_restore_water.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720">
+  <defs>
+    <linearGradient id="restoreGradient" x1="100%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#00BED6" />
+      <stop offset="100%" stop-color="#00BED6" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1280" height="720" fill="url(#restoreGradient)" rx="48" />
+  <rect width="1280" height="720" fill="url(#glow)" />
+  <g opacity="0.25" stroke="#FFFFFF" stroke-width="6" stroke-linecap="round">
+    <path d="M160 520 q160 -220 360 -40" fill="none" />
+    <path d="M1160 180 q-200 260 -420 80" fill="none" />
+    <circle cx="260" cy="220" r="60" fill="none" />
+    <circle cx="1010" cy="540" r="80" fill="none" />
+  </g>
+  <g fill="#FFFFFF" text-anchor="middle" font-family="'Noto Sans TC', 'PingFang TC', sans-serif">
+    <text x="640" y="320" font-size="70" font-weight="700">家裡突然斷水？</text>
+    <text x="640" y="395" font-size="48" font-weight="600">3 步立刻恢復用水教學</text>
+    <text x="640" y="468" font-size="32" font-weight="500" opacity="0.85">跟著影片一步步排查</text>
+  </g>
+  <g transform="translate(640 525)">
+    <circle r="78" fill="rgba(255, 255, 255, 0.2)" />
+    <circle r="66" fill="rgba(255, 255, 255, 0.4)" />
+    <polygon points="-18,-28 32,0 -18,28" fill="#FFFFFF" />
+  </g>
+</svg>

--- a/assets/tip_title.svg
+++ b/assets/tip_title.svg
@@ -1,0 +1,4 @@
+<svg width="720" height="120" viewBox="0 0 720 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="720" height="120" rx="24" fill="#00BED6" />
+  <text x="360" y="74" text-anchor="middle" font-family="'Noto Sans TC', 'PingFang TC', 'Microsoft JhengHei', sans-serif" font-size="54" font-weight="700" fill="white">提提你</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -15,9 +15,15 @@
     <section class="card upload-section">
       <h2 class="section-title">上傳維修紀錄照片</h2>
       <p>請選擇一或多張維修紀錄照片，我們會為您生成專屬回訪報告。</p>
-      <!-- 選擇下次保養日期 -->
-      <label for="nextDate" style="display:block;margin:8px 0 4px;font-weight:600;">下次保養日期：</label>
-      <input type="date" id="nextDate" class="date-input">
+      <!-- 選擇本次與下次保養日期 -->
+      <div class="date-stack">
+        <label for="serviceDate" class="field-label">本次保養日期：</label>
+        <input type="date" id="serviceDate" class="date-input">
+      </div>
+      <div class="date-stack">
+        <label for="nextDate" class="field-label">下次保養日期：</label>
+        <input type="date" id="nextDate" class="date-input">
+      </div>
       <!-- 隱藏原生檔案輸入框，改用自訂樣式的按鈕觸發檔案選取 -->
       <input type="file" id="fileInput" class="file-input" accept="image/*" multiple hidden>
       <label for="fileInput" class="upload-btn">選擇照片</label>
@@ -122,14 +128,19 @@
           const result = await response.json();
           ids.push(result.public_id);
         }
-        // 取得下次保養日期
-        const dateInput = document.getElementById('nextDate');
-        const dateValue = dateInput && dateInput.value ? dateInput.value : '';
+        // 取得本次與下次保養日期
+        const serviceDateInput = document.getElementById('serviceDate');
+        const nextDateInput = document.getElementById('nextDate');
+        const serviceDateValue = serviceDateInput && serviceDateInput.value ? serviceDateInput.value : '';
+        const nextDateValue = nextDateInput && nextDateInput.value ? nextDateInput.value : '';
         // 組成查詢字串
         const paramIds = encodeURIComponent(ids.join(','));
         let url = 'report.html?ids=' + paramIds;
-        if (dateValue) {
-          url += '&date=' + encodeURIComponent(dateValue);
+        if (serviceDateValue) {
+          url += '&serviceDate=' + encodeURIComponent(serviceDateValue);
+        }
+        if (nextDateValue) {
+          url += '&date=' + encodeURIComponent(nextDateValue);
         }
         // 導向至報告頁面
         window.location.href = url;

--- a/report.html
+++ b/report.html
@@ -30,7 +30,7 @@
     <div class="videos-section">
       <!-- 第一個影片：顯示自動斷水裝置介紹 -->
       <div class="video-item">
-        <video controls playsinline preload="metadata">
+        <video controls playsinline preload="metadata" poster="assets/poster_leak_stop.svg">
           <source src="assets/1252_1757912418.mp4" type="video/mp4">
         </video>
         <!-- 標題覆蓋於影片預覽，簡要描述影片內容，吸引用戶點擊 -->
@@ -39,7 +39,7 @@
       </div>
       <!-- 第二個影片：顯示如何快速恢復用水 -->
       <div class="video-item">
-        <video controls playsinline preload="metadata">
+        <video controls playsinline preload="metadata" poster="assets/poster_restore_water.svg">
           <source src="assets/1253_1757912439.mp4" type="video/mp4">
         </video>
         <div class="caption">家裡突然斷水？3步立刻搞定</div>

--- a/report.html
+++ b/report.html
@@ -48,17 +48,13 @@
     <div id="slidesContainer" class="slides-wrapper"></div>
     <!-- 提提你區塊：使用設計稿原圖作為封面，點擊後播放影片 -->
     <section class="videos-section" aria-label="提提你影片">
-      <div class="videos-preamble">提提你</div>
+      <h2 class="videos-heading">提提你</h2>
       <div class="video-grid">
-        <button class="video-card" type="button" data-video="assets/1252_1757912418.mp4">
-          <img src="assets/poster_leak_stop.svg" alt="全屋漏水不用怕！1秒自動斷水防災裝置影片封面">
-          <span class="sr-only">播放：全屋漏水不用怕！1秒自動斷水防災裝置</span>
-          <span class="play-badge" aria-hidden="true"></span>
+        <button class="video-card" type="button" data-video="assets/1252_1757912418.mp4" aria-label="播放影片：全屋漏水不用怕！1秒自動斷水防災裝置">
+          <img src="assets/poster_leak_stop.svg" alt="">
         </button>
-        <button class="video-card" type="button" data-video="assets/1253_1757912439.mp4">
-          <img src="assets/poster_restore_water.svg" alt="家裡突然斷水？3步立刻搞定影片封面">
-          <span class="sr-only">播放：家裡突然斷水？3步立刻搞定</span>
-          <span class="play-badge" aria-hidden="true"></span>
+        <button class="video-card" type="button" data-video="assets/1253_1757912439.mp4" aria-label="播放影片：家裡突然斷水？3步立刻搞定">
+          <img src="assets/poster_restore_water.svg" alt="">
         </button>
       </div>
     </section>

--- a/report.html
+++ b/report.html
@@ -46,26 +46,26 @@
 
     <!-- 保養紀錄圖片輪播 -->
     <div id="slidesContainer" class="slides-wrapper"></div>
-    <!-- 提提你區塊：使用設計稿原圖作為封面，點擊後播放影片 -->
-    <section class="videos-section" aria-label="提提你影片">
-      <h2 class="videos-heading">提提你</h2>
-      <div class="video-grid">
+    <!-- 提提你與設計稿：使用原始圖片堆疊呈現 -->
+    <section class="tip-stack" aria-labelledby="tipStackTitle">
+      <h2 id="tipStackTitle" class="sr-only">提提你</h2>
+      <div class="tip-title">
+        <img src="assets/tip_title.svg" alt="提提你">
+      </div>
+      <div class="tip-videos">
         <button class="video-card" type="button" data-video="assets/1252_1757912418.mp4" aria-label="播放影片：全屋漏水不用怕！1秒自動斷水防災裝置">
-          <img src="assets/poster_leak_stop.svg" alt="">
+          <img src="assets/poster_leak_stop.svg" alt="全屋漏水不用怕！1秒自動斷水防災裝置影片封面">
         </button>
         <button class="video-card" type="button" data-video="assets/1253_1757912439.mp4" aria-label="播放影片：家裡突然斷水？3步立刻搞定">
-          <img src="assets/poster_restore_water.svg" alt="">
+          <img src="assets/poster_restore_water.svg" alt="家裡突然斷水？3步立刻搞定影片封面">
         </button>
       </div>
-    </section>
-
-    <!-- 設計版面中固定的服務與推薦圖像 -->
-    <section class="design-illustration">
-      <img src="assets/services_grid.jpg" alt="我們的承諾 Anytime, Anywhere 服務介紹">
-    </section>
-
-    <section class="design-illustration">
-      <img src="assets/referral_reward.jpg" alt="介紹朋友 限量 2,000 元月費獎賞">
+      <div class="tip-artwork">
+        <img src="assets/services_grid.jpg" alt="我們的承諾 Anytime, Anywhere 服務介紹">
+      </div>
+      <div class="tip-artwork">
+        <img src="assets/referral_reward.jpg" alt="介紹朋友 限量 2,000 元月費獎賞">
+      </div>
     </section>
   </main>
   <!-- 圖片放大顯示遮罩 -->

--- a/report.html
+++ b/report.html
@@ -16,14 +16,21 @@
     <!-- 問候語及保養紀錄按鈕卡片 -->
     <section class="intro-card">
       <div id="greeting" class="greeting-text"></div>
+      <div class="status-board" aria-live="polite">
+        <div class="status-row">
+          <span class="status-label">下次保養時間</span>
+          <span class="status-value" id="nextDateValue">待安排</span>
+        </div>
+        <div class="status-row">
+          <span class="status-label">問卷連結</span>
+          <a class="status-value status-link" id="surveyLink" href="http://forms.gle/1mtZCkrerNMY8iZA8" target="_blank" rel="noopener noreferrer">http://forms.gle/1mtZCkrerNMY8iZA8</a>
+        </div>
+      </div>
       <button class="btn records-btn" type="button">保養紀錄</button>
     </section>
 
     <!-- 保養紀錄圖片輪播 -->
     <div id="slidesContainer" class="slides-wrapper"></div>
-    <!-- 下一次保養日期提示 -->
-    <p id="nextDateText" class="next-date-text"></p>
-
     <!-- 提提你按鈕 -->
     <button class="btn tip-btn" type="button">提提你</button>
     <!-- 影片堆疊 -->
@@ -112,9 +119,14 @@
         }
       }
       greetingDiv.innerHTML = `
-        <p>您好啊～我是 <strong>MAQUA 淨水管家</strong> 的客服！</p>
-        <p>這次為您提供的是<strong>保養維修記錄</strong>，特別感謝您一直信任我們的服務！</p>
-        <p>若使用中遇到任何問題，隨時聯絡我們，我們會及時為你處理。</p>
+        <div class="greeting-block">
+          <span class="greeting-emoji" aria-hidden="true">👏</span>
+          <div class="greeting-lines">
+            <p>今天已經幫您完成這次的保養維護，設備狀態一切良好，請安心使用～</p>
+            <p>感謝一直以來讓我們陪伴在您身邊！</p>
+          </div>
+        </div>
+        <p class="greeting-subline">我們會不斷優化服務，懇請你向我們大膽評價！</p>
       `;
     })();
     
@@ -222,8 +234,12 @@
 
     // 更新下一次保養日期文字，放在圖片處理完成後
     (function updateNextDate() {
-      const nextEl = document.getElementById('nextDateText');
-      if (!nextEl) return;
+      const dateEl = document.getElementById('nextDateValue');
+      const surveyEl = document.getElementById('surveyLink');
+      if (surveyEl && !surveyEl.textContent.trim()) {
+        surveyEl.textContent = surveyEl.href;
+      }
+      if (!dateEl) return;
       const dateParam = getQueryParam('date');
       if (dateParam) {
         try {
@@ -233,8 +249,7 @@
             const m = parseInt(parts[1], 10);
             const d = parseInt(parts[2], 10);
             if (!isNaN(y) && !isNaN(m) && !isNaN(d)) {
-              // 日期訊息與問卷訊息合併
-              nextEl.innerHTML = `下一次保養預計於 <strong>${y}年${m}月${d}日</strong>，屆時會再次為您服務～<br>麻煩您撥出少量時間填寫一份簡單小問卷：<a href="http://forms.gle/1mtZCkrerNMY8iZA8" target="_blank">http://forms.gle/1mtZCkrerNMY8iZA8</a>，感謝您的配合！`;
+              dateEl.textContent = `${y}年${m}月${d}日`;
               return;
             }
           }
@@ -242,8 +257,7 @@
           console.warn('無法解析日期參數');
         }
       }
-      // 如果沒有日期，顯示預設問卷提示
-      nextEl.innerHTML = `麻煩您撥出少量時間填寫一份簡單小問卷：<a href="http://forms.gle/1mtZCkrerNMY8iZA8" target="_blank">http://forms.gle/1mtZCkrerNMY8iZA8</a>`;
+      dateEl.textContent = '待安排';
     })();
   </script>
   <!-- 自定義播放按鈕行為：當點擊覆蓋層時播放影片，影片暫停時恢復覆蓋層 -->

--- a/report.html
+++ b/report.html
@@ -15,7 +15,17 @@
   <main class="container">
     <!-- 問候語及保養紀錄按鈕卡片 -->
     <section class="intro-card">
-      <div id="greeting" class="greeting-text"></div>
+      <div id="greeting" class="greeting-text">
+        <div class="greeting-block">
+          <span class="greeting-emoji" aria-hidden="true">👏</span>
+          <div class="greeting-lines">
+            <p>今天已經幫您完成這次的保養維護，設備狀態一切良好，請安心使用～</p>
+            <p>感謝一直以來讓我們陪伴在您身邊！</p>
+          </div>
+        </div>
+        <p class="greeting-note">下一次保養預計於 <span id="nextDateInline">待安排</span>，屆時我們將再次為您服務。</p>
+        <p class="greeting-subline">我們會不斷優化服務，懇請你向我們大膽評價！</p>
+      </div>
       <div class="status-board" aria-live="polite">
         <div class="status-row">
           <span class="status-label">下次保養時間</span>
@@ -95,41 +105,6 @@
     const idsParam = getQueryParam('ids');
     const urlsParam = getQueryParam('urls');
 
-    // 根據日期動態生成問候文案
-    (function generateGreeting() {
-      const greetingDiv = document.getElementById('greeting');
-      if (!greetingDiv) return;
-      const dateParam = getQueryParam('date');
-      let dateHtml = '';
-      if (dateParam) {
-        try {
-          // 直接解析 yyyy-mm-dd，避免時區偏移
-          const parts = dateParam.split('-');
-          if (parts.length === 3) {
-            const y = parseInt(parts[0], 10);
-            const m = parseInt(parts[1], 10);
-            const d = parseInt(parts[2], 10);
-            if (!isNaN(y) && !isNaN(m) && !isNaN(d)) {
-              const formatted = `${y}年${m}月${d}日`;
-              dateHtml = `<p>下一次保養預計於 <strong>${formatted}</strong>，屆時我們將再次為您服務。</p>`;
-            }
-          }
-        } catch (e) {
-          console.warn('無法解析日期參數');
-        }
-      }
-      greetingDiv.innerHTML = `
-        <div class="greeting-block">
-          <span class="greeting-emoji" aria-hidden="true">👏</span>
-          <div class="greeting-lines">
-            <p>今天已經幫您完成這次的保養維護，設備狀態一切良好，請安心使用～</p>
-            <p>感謝一直以來讓我們陪伴在您身邊！</p>
-          </div>
-        </div>
-        <p class="greeting-subline">我們會不斷優化服務，懇請你向我們大膽評價！</p>
-      `;
-    })();
-    
     /**
      * 將圖片網址（或 public_id）建立為輪播幻燈片
      * @param {string[]} list 圖片網址或 public_id 陣列
@@ -235,6 +210,7 @@
     // 更新下一次保養日期文字，放在圖片處理完成後
     (function updateNextDate() {
       const dateEl = document.getElementById('nextDateValue');
+      const inlineDateEl = document.getElementById('nextDateInline');
       const surveyEl = document.getElementById('surveyLink');
       if (surveyEl && !surveyEl.textContent.trim()) {
         surveyEl.textContent = surveyEl.href;
@@ -249,7 +225,11 @@
             const m = parseInt(parts[1], 10);
             const d = parseInt(parts[2], 10);
             if (!isNaN(y) && !isNaN(m) && !isNaN(d)) {
-              dateEl.textContent = `${y}年${m}月${d}日`;
+              const formatted = `${y}年${m}月${d}日`;
+              dateEl.textContent = formatted;
+              if (inlineDateEl) {
+                inlineDateEl.textContent = formatted;
+              }
               return;
             }
           }
@@ -258,6 +238,9 @@
         }
       }
       dateEl.textContent = '待安排';
+      if (inlineDateEl) {
+        inlineDateEl.textContent = '待安排';
+      }
     })();
   </script>
   <!-- 自定義播放按鈕行為：當點擊覆蓋層時播放影片，影片暫停時恢復覆蓋層 -->

--- a/report.html
+++ b/report.html
@@ -6,7 +6,7 @@
   <title>維修回訪報告</title>
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="report-page">
   <!-- 頂部橫幅：整幅品牌橫幅佔滿頁面寬度 -->
   <header class="header">
     <img src="assets/banner_maqua.jpg" alt="MAQUA 服務小回顧" class="banner">

--- a/report.html
+++ b/report.html
@@ -23,10 +23,15 @@
             <p>感謝一直以來讓我們陪伴在您身邊！</p>
           </div>
         </div>
+        <p class="greeting-note">本次保養時間：<span id="serviceDateInline">今日完成</span></p>
         <p class="greeting-note">下一次保養預計於 <span id="nextDateInline">待安排</span>，屆時我們將再次為您服務。</p>
         <p class="greeting-subline">我們會不斷優化服務，懇請你向我們大膽評價！</p>
       </div>
       <div class="status-board" aria-live="polite">
+        <div class="status-row">
+          <span class="status-label">本次保養時間</span>
+          <span class="status-value" id="serviceDateValue">今日完成</span>
+        </div>
         <div class="status-row">
           <span class="status-label">下次保養時間</span>
           <span class="status-value" id="nextDateValue">待安排</span>
@@ -207,39 +212,53 @@
       if (slidesContainer) slidesContainer.innerHTML = '<p>沒有找到照片資料。</p>';
     }
 
-    // 更新下一次保養日期文字，放在圖片處理完成後
-    (function updateNextDate() {
-      const dateEl = document.getElementById('nextDateValue');
-      const inlineDateEl = document.getElementById('nextDateInline');
+    // 更新本次與下次保養日期文字，放在圖片處理完成後
+    (function updateDates() {
+      const nextDateEl = document.getElementById('nextDateValue');
+      const inlineNextDateEl = document.getElementById('nextDateInline');
+      const serviceDateEl = document.getElementById('serviceDateValue');
+      const inlineServiceDateEl = document.getElementById('serviceDateInline');
       const surveyEl = document.getElementById('surveyLink');
       if (surveyEl && !surveyEl.textContent.trim()) {
         surveyEl.textContent = surveyEl.href;
       }
-      if (!dateEl) return;
-      const dateParam = getQueryParam('date');
-      if (dateParam) {
+
+      const formatDate = (value) => {
+        if (!value) return null;
         try {
-          const parts = dateParam.split('-');
+          const parts = value.split('-');
           if (parts.length === 3) {
             const y = parseInt(parts[0], 10);
             const m = parseInt(parts[1], 10);
             const d = parseInt(parts[2], 10);
             if (!isNaN(y) && !isNaN(m) && !isNaN(d)) {
-              const formatted = `${y}年${m}月${d}日`;
-              dateEl.textContent = formatted;
-              if (inlineDateEl) {
-                inlineDateEl.textContent = formatted;
-              }
-              return;
+              return `${y}年${m}月${d}日`;
             }
           }
         } catch (e) {
           console.warn('無法解析日期參數');
         }
+        return null;
+      };
+
+      const nextFormatted = formatDate(getQueryParam('date'));
+      if (nextDateEl) {
+        const fallback = '待安排';
+        const value = nextFormatted || fallback;
+        nextDateEl.textContent = value;
+        if (inlineNextDateEl) {
+          inlineNextDateEl.textContent = value;
+        }
       }
-      dateEl.textContent = '待安排';
-      if (inlineDateEl) {
-        inlineDateEl.textContent = '待安排';
+
+      const serviceFormatted = formatDate(getQueryParam('serviceDate'));
+      if (serviceDateEl) {
+        const fallback = serviceDateEl.textContent || '今日完成';
+        const value = serviceFormatted || fallback;
+        serviceDateEl.textContent = value;
+        if (inlineServiceDateEl) {
+          inlineServiceDateEl.textContent = value;
+        }
       }
     })();
   </script>

--- a/report.html
+++ b/report.html
@@ -46,42 +46,30 @@
 
     <!-- 保養紀錄圖片輪播 -->
     <div id="slidesContainer" class="slides-wrapper"></div>
-    <!-- 提提你按鈕 -->
-    <button class="btn tip-btn" type="button">提提你</button>
-    <!-- 影片堆疊 -->
-    <div class="videos-section">
-      <!-- 第一個影片：顯示自動斷水裝置介紹 -->
-      <div class="video-item">
-        <video controls playsinline preload="metadata" poster="assets/poster_leak_stop.svg">
-          <source src="assets/1252_1757912418.mp4" type="video/mp4">
-        </video>
-        <!-- 標題覆蓋於影片預覽，簡要描述影片內容，吸引用戶點擊 -->
-        <div class="caption">全屋漏水不用怕！1秒自動斷水防災裝置</div>
-        <button class="play-overlay" aria-label="播放"></button>
+    <!-- 提提你區塊：使用設計稿原圖作為封面，點擊後播放影片 -->
+    <section class="videos-section" aria-label="提提你影片">
+      <div class="videos-preamble">提提你</div>
+      <div class="video-grid">
+        <button class="video-card" type="button" data-video="assets/1252_1757912418.mp4">
+          <img src="assets/poster_leak_stop.svg" alt="全屋漏水不用怕！1秒自動斷水防災裝置影片封面">
+          <span class="sr-only">播放：全屋漏水不用怕！1秒自動斷水防災裝置</span>
+          <span class="play-badge" aria-hidden="true"></span>
+        </button>
+        <button class="video-card" type="button" data-video="assets/1253_1757912439.mp4">
+          <img src="assets/poster_restore_water.svg" alt="家裡突然斷水？3步立刻搞定影片封面">
+          <span class="sr-only">播放：家裡突然斷水？3步立刻搞定</span>
+          <span class="play-badge" aria-hidden="true"></span>
+        </button>
       </div>
-      <!-- 第二個影片：顯示如何快速恢復用水 -->
-      <div class="video-item">
-        <video controls playsinline preload="metadata" poster="assets/poster_restore_water.svg">
-          <source src="assets/1253_1757912439.mp4" type="video/mp4">
-        </video>
-        <div class="caption">家裡突然斷水？3步立刻搞定</div>
-        <button class="play-overlay" aria-label="播放"></button>
-      </div>
-    </div>
-
-    <!-- 我們的服務區塊 -->
-    <section class="services-wrapper">
-      <!-- 圖片本身已包含 "我們的服務" 標題，因此不重複顯示文字 -->
-      <img src="assets/services_grid.jpg" alt="我們的服務">
     </section>
 
-    <!-- 介紹朋友月費獎賞區塊 -->
-    <section class="referral-wrapper">
-      <div class="referral-img-box">
-        <!-- 圖片本身已有文案，無需額外覆蓋文字 -->
-        <img src="assets/referral_reward.jpg" alt="介紹朋友月費獎賞">
-      </div>
-      <button class="btn share-btn" type="button">分享好友</button>
+    <!-- 設計版面中固定的服務與推薦圖像 -->
+    <section class="design-illustration">
+      <img src="assets/services_grid.jpg" alt="我們的承諾 Anytime, Anywhere 服務介紹">
+    </section>
+
+    <section class="design-illustration">
+      <img src="assets/referral_reward.jpg" alt="介紹朋友 限量 2,000 元月費獎賞">
     </section>
   </main>
   <!-- 圖片放大顯示遮罩 -->
@@ -265,26 +253,12 @@
   <!-- 自定義播放按鈕行為：當點擊覆蓋層時播放影片，影片暫停時恢復覆蓋層 -->
   <script>
     document.addEventListener('DOMContentLoaded', function () {
-      // 對於每個影片容器，綁定播放覆蓋層和容器本身的點擊事件
-      const videoItems = document.querySelectorAll('.video-item');
-      videoItems.forEach(item => {
-        const overlay = item.querySelector('.play-overlay');
-        const sourceEl = item.querySelector('source');
-        if (!sourceEl || !overlay) return;
-        // 點擊覆蓋按鈕時放大播放
-        overlay.addEventListener('click', (e) => {
-          e.stopPropagation();
-          const src = sourceEl.getAttribute('src');
-          if (src) {
-            showVideoOverlay(src);
-          }
-        });
-        // 點擊整個影片容器時亦放大播放
-        item.addEventListener('click', () => {
-          const src = sourceEl.getAttribute('src');
-          if (src) {
-            showVideoOverlay(src);
-          }
+      const videoCards = document.querySelectorAll('.video-card');
+      videoCards.forEach(card => {
+        const src = card.getAttribute('data-video');
+        if (!src) return;
+        card.addEventListener('click', () => {
+          showVideoOverlay(src);
         });
       });
     });

--- a/style.css
+++ b/style.css
@@ -1341,44 +1341,36 @@ body.report-page .design-illustration {
 
 body.report-page .videos-section {
   width: 100%;
-  background: var(--brand);
-  border-radius: 28px;
-  padding: 36px 32px 44px;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 32px;
-  box-shadow: 0 18px 36px rgba(0, 190, 214, 0.25);
-  color: #FFFFFF;
+  align-items: stretch;
+  gap: 24px;
+  padding: 0;
+  background: none;
+  box-shadow: none;
+  color: inherit;
 }
 
-body.report-page .videos-preamble {
-  font-size: 1.05rem;
+body.report-page .videos-heading {
+  margin: 0;
+  font-size: 1.2rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  padding: 10px 24px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.18);
+  color: var(--brand);
 }
 
 body.report-page .video-grid {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 24px;
 }
 
 body.report-page .video-card {
-  position: relative;
   border: none;
   padding: 0;
   background: none;
-  border-radius: 24px;
-  overflow: hidden;
   cursor: pointer;
-  box-shadow: 0 14px 30px rgba(9, 30, 66, 0.25);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: block;
 }
 
 body.report-page .video-card img {
@@ -1387,51 +1379,18 @@ body.report-page .video-card img {
   height: auto;
 }
 
-body.report-page .video-card .play-badge {
-  position: absolute;
-  top: 22px;
-  right: 22px;
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.94);
-  box-shadow: 0 12px 28px rgba(9, 30, 66, 0.25);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-body.report-page .video-card .play-badge::before {
-  content: "";
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-width: 14px 0 14px 22px;
-  border-color: transparent transparent transparent rgba(55, 65, 81, 0.85);
-  transform: translateX(2px);
-}
-
 body.report-page .video-card:focus-visible {
-  outline: 3px solid rgba(255, 255, 255, 0.7);
-  outline-offset: -6px;
-}
-
-body.report-page .video-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 18px 36px rgba(9, 30, 66, 0.28);
+  outline: 3px solid rgba(0, 190, 214, 0.4);
+  outline-offset: 4px;
 }
 
 body.report-page .design-illustration {
   width: 100%;
-  display: flex;
-  justify-content: center;
 }
 
 body.report-page .design-illustration img {
   width: 100%;
   display: block;
-  border-radius: 28px;
-  box-shadow: 0 16px 36px rgba(11, 24, 33, 0.12);
 }
 
 body.report-page .next-date-text {
@@ -1463,28 +1422,10 @@ body.report-page .referral-wrapper .share-btn {
   }
 
   body.report-page .videos-section {
-    padding: 28px 20px 36px;
-    border-radius: 24px;
-    gap: 26px;
+    gap: 20px;
   }
 
   body.report-page .video-grid {
-    gap: 22px;
-  }
-
-  body.report-page .video-card {
-    border-radius: 20px;
-  }
-
-  body.report-page .video-card .play-badge {
-    top: 18px;
-    right: 18px;
-    width: 56px;
-    height: 56px;
-    box-shadow: 0 10px 24px rgba(9, 30, 66, 0.22);
-  }
-
-  body.report-page .design-illustration img {
-    border-radius: 24px;
+    gap: 20px;
   }
 }

--- a/style.css
+++ b/style.css
@@ -729,12 +729,43 @@ a {
   }
 }
 
+/* Upload section layout on the index page */
+.upload-section {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.upload-section p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.98rem;
+  line-height: 1.6;
+}
+
+.date-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field-label {
+  display: block;
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: var(--text);
+}
+
 /* Preview area on the upload page */
 .preview {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  margin-top: 12px;
+  margin: 0;
 }
 
 .preview img {
@@ -757,13 +788,18 @@ a {
   background: var(--brand);
   color: #FFFFFF;
   border: none;
-  border-radius: var(--radius);
-  padding: 14px 0;
-  font-size: 1rem;
+  border-radius: calc(var(--radius) + 2px);
+  padding: 16px 0;
+  font-size: 1.08rem;
   font-weight: 600;
   text-align: center;
-  margin: 16px 0;
+  margin: 0;
   cursor: pointer;
+  box-shadow: 0 6px 18px rgba(0, 190, 214, 0.18);
+}
+
+.upload-btn:hover {
+  background: #009CB3;
 }
 
 /* General button styling */
@@ -784,16 +820,25 @@ button:hover {
   background: #009CB3; /* slightly darker brand shade on hover */
 }
 
+#generateBtn {
+  width: 100%;
+  padding: 16px 0;
+  font-size: 1.05rem;
+  box-shadow: 0 6px 18px rgba(0, 190, 214, 0.18);
+}
+
 /* 日期輸入框樣式 */
 .date-input {
   display: block;
   width: 100%;
   /* 增大日期輸入框尺寸，讓其更易於操作 */
-  padding: 14px 16px;
+  padding: 16px 18px;
   border: 1px solid #CCCCCC;
-  border-radius: var(--radius);
-  font-size: 1.05rem;
-  margin-bottom: 16px;
+  border-radius: calc(var(--radius) + 2px);
+  font-size: 1.12rem;
+  margin: 0;
+  background: #ffffff;
+  box-shadow: inset 0 2px 6px rgba(11, 24, 33, 0.04);
 }
 
 /* 影像放大顯示的遮罩層 */

--- a/style.css
+++ b/style.css
@@ -1098,6 +1098,11 @@ main.container > * + * {
 }
 
 /* 報告頁面最終排版調整：加大間距與容器寬度 */
+body.report-page {
+  background: #f7fbfd;
+  color: #5B6E80;
+}
+
 body.report-page main.container {
   max-width: 640px;
   padding: 36px 36px 64px;
@@ -1152,6 +1157,18 @@ body.report-page .greeting-lines p {
   font-size: 0.95rem;
   line-height: 1.6;
   color: inherit;
+}
+
+body.report-page .greeting-note {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: inherit;
+}
+
+body.report-page .greeting-note span {
+  color: var(--brand);
+  font-weight: 600;
 }
 
 body.report-page .greeting-lines p:first-child {

--- a/style.css
+++ b/style.css
@@ -25,6 +25,17 @@ body {
   color: var(--text);
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 /* Header containing the brand banner */
 /* Header containing the brand banner */
 .header {
@@ -1189,12 +1200,12 @@ body.report-page {
 }
 
 body.report-page main.container {
-  max-width: 640px;
-  padding: 36px 36px 64px;
+  max-width: 680px;
+  padding: 40px 40px 72px;
   display: flex;
   flex-direction: column;
-  gap: 36px;
-  text-align: left;
+  gap: 40px;
+  text-align: center;
 }
 
 body.report-page main.container > * + * {
@@ -1204,12 +1215,13 @@ body.report-page main.container > * + * {
 body.report-page .intro-card {
   margin-top: -44px;
   margin-bottom: 0;
-  padding: 32px 28px;
+  padding: 36px 32px;
   box-shadow: 0 8px 24px rgba(11, 24, 33, 0.08);
   display: flex;
   flex-direction: column;
   gap: 24px;
-  text-align: left;
+  text-align: center;
+  align-items: center;
   color: var(--muted);
 }
 
@@ -1217,11 +1229,14 @@ body.report-page .greeting-text {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  align-items: center;
+  text-align: center;
 }
 
 body.report-page .greeting-block {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
+  justify-content: center;
   gap: 12px;
 }
 
@@ -1235,6 +1250,7 @@ body.report-page .greeting-lines {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  text-align: center;
 }
 
 body.report-page .greeting-lines p {
@@ -1276,6 +1292,10 @@ body.report-page .status-board {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  align-self: stretch;
+  max-width: 440px;
+  margin: 0 auto;
+  text-align: left;
 }
 
 body.report-page .status-row {
@@ -1315,14 +1335,103 @@ body.report-page .intro-card .btn {
 
 body.report-page .slides-wrapper,
 body.report-page .next-date-text,
-body.report-page .videos-section,
-body.report-page .services-wrapper,
-body.report-page .referral-wrapper {
+body.report-page .design-illustration {
   margin: 0;
 }
 
 body.report-page .videos-section {
+  width: 100%;
+  background: var(--brand);
+  border-radius: 28px;
+  padding: 36px 32px 44px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+  box-shadow: 0 18px 36px rgba(0, 190, 214, 0.25);
+  color: #FFFFFF;
+}
+
+body.report-page .videos-preamble {
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 10px 24px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+body.report-page .video-grid {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
   gap: 28px;
+}
+
+body.report-page .video-card {
+  position: relative;
+  border: none;
+  padding: 0;
+  background: none;
+  border-radius: 24px;
+  overflow: hidden;
+  cursor: pointer;
+  box-shadow: 0 14px 30px rgba(9, 30, 66, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+body.report-page .video-card img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+body.report-page .video-card .play-badge {
+  position: absolute;
+  top: 22px;
+  right: 22px;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 12px 28px rgba(9, 30, 66, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+body.report-page .video-card .play-badge::before {
+  content: "";
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 14px 0 14px 22px;
+  border-color: transparent transparent transparent rgba(55, 65, 81, 0.85);
+  transform: translateX(2px);
+}
+
+body.report-page .video-card:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.7);
+  outline-offset: -6px;
+}
+
+body.report-page .video-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 36px rgba(9, 30, 66, 0.28);
+}
+
+body.report-page .design-illustration {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+body.report-page .design-illustration img {
+  width: 100%;
+  display: block;
+  border-radius: 28px;
+  box-shadow: 0 16px 36px rgba(11, 24, 33, 0.12);
 }
 
 body.report-page .next-date-text {
@@ -1344,12 +1453,38 @@ body.report-page .referral-wrapper .share-btn {
 
 @media (max-width: 600px) {
   body.report-page main.container {
-    padding: 24px 20px 44px;
-    gap: 28px;
+    padding: 28px 20px 52px;
+    gap: 32px;
   }
 
   body.report-page .intro-card {
-    margin-top: -36px;
-    padding: 28px 22px;
+    margin-top: -32px;
+    padding: 30px 22px;
+  }
+
+  body.report-page .videos-section {
+    padding: 28px 20px 36px;
+    border-radius: 24px;
+    gap: 26px;
+  }
+
+  body.report-page .video-grid {
+    gap: 22px;
+  }
+
+  body.report-page .video-card {
+    border-radius: 20px;
+  }
+
+  body.report-page .video-card .play-badge {
+    top: 18px;
+    right: 18px;
+    width: 56px;
+    height: 56px;
+    box-shadow: 0 10px 24px rgba(9, 30, 66, 0.22);
+  }
+
+  body.report-page .design-illustration img {
+    border-radius: 24px;
   }
 }

--- a/style.css
+++ b/style.css
@@ -1096,3 +1096,65 @@ main.container > * + * {
 .referral-wrapper .share-btn {
   margin-top: 24px;
 }
+
+/* 報告頁面最終排版調整：加大間距與容器寬度 */
+body.report-page main.container {
+  max-width: 640px;
+  padding: 36px 36px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  text-align: center;
+}
+
+body.report-page main.container > * + * {
+  margin-top: 0;
+}
+
+body.report-page .intro-card {
+  margin-top: -44px;
+  margin-bottom: 0;
+  padding: 32px 28px;
+  box-shadow: 0 8px 24px rgba(11, 24, 33, 0.08);
+}
+
+body.report-page .slides-wrapper,
+body.report-page .next-date-text,
+body.report-page .videos-section,
+body.report-page .services-wrapper,
+body.report-page .referral-wrapper {
+  margin: 0;
+}
+
+body.report-page .videos-section {
+  gap: 28px;
+}
+
+body.report-page .next-date-text {
+  text-align: center;
+}
+
+body.report-page .btn.tip-btn {
+  margin: 0;
+}
+
+body.report-page .services-wrapper,
+body.report-page .referral-wrapper {
+  width: 100%;
+}
+
+body.report-page .referral-wrapper .share-btn {
+  margin: 16px auto 0;
+}
+
+@media (max-width: 600px) {
+  body.report-page main.container {
+    padding: 24px 20px 44px;
+    gap: 28px;
+  }
+
+  body.report-page .intro-card {
+    margin-top: -36px;
+    padding: 28px 22px;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1103,8 +1103,8 @@ body.report-page main.container {
   padding: 36px 36px 64px;
   display: flex;
   flex-direction: column;
-  gap: 40px;
-  text-align: center;
+  gap: 36px;
+  text-align: left;
 }
 
 body.report-page main.container > * + * {
@@ -1116,6 +1116,99 @@ body.report-page .intro-card {
   margin-bottom: 0;
   padding: 32px 28px;
   box-shadow: 0 8px 24px rgba(11, 24, 33, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  text-align: left;
+  color: #5B6E80;
+}
+
+body.report-page .greeting-text {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+body.report-page .greeting-block {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+body.report-page .greeting-emoji {
+  font-size: 1.75rem;
+  line-height: 1;
+  color: var(--brand);
+}
+
+body.report-page .greeting-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+body.report-page .greeting-lines p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: inherit;
+}
+
+body.report-page .greeting-lines p:first-child {
+  font-weight: 600;
+}
+
+body.report-page .greeting-subline {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: inherit;
+  font-weight: 500;
+}
+
+body.report-page .status-board {
+  background: #F1F6FA;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 190, 214, 0.15);
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+body.report-page .status-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.95rem;
+}
+
+body.report-page .status-row + .status-row {
+  border-top: 1px solid rgba(11, 24, 33, 0.08);
+  padding-top: 10px;
+}
+
+body.report-page .status-label {
+  font-weight: 600;
+  color: #5B6E80;
+}
+
+body.report-page .status-value {
+  color: var(--brand);
+  font-weight: 600;
+  text-decoration: none;
+  word-break: break-word;
+}
+
+body.report-page .status-link:hover,
+body.report-page .status-link:focus {
+  text-decoration: underline;
+}
+
+body.report-page .intro-card .btn {
+  margin: 0;
 }
 
 body.report-page .slides-wrapper,

--- a/style.css
+++ b/style.css
@@ -141,7 +141,7 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba(0, 0, 0, 0.4);
+  background: none;
   border: none;
   cursor: pointer;
   transition: opacity 0.2s ease;
@@ -149,10 +149,24 @@ body {
 }
 .play-overlay::before {
   content: "";
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  background: rgba(240, 242, 245, 0.92);
+  box-shadow: 0 6px 18px rgba(9, 30, 66, 0.18);
+  display: block;
+}
+.play-overlay::after {
+  content: "";
+  position: absolute;
+  width: 0;
+  height: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-30%, -50%);
   border-style: solid;
-  /* 調整全局播放按鈕尺寸為一半 */
-  border-width: 18px 0 18px 30px;
-  border-color: transparent transparent transparent #ffffff;
+  border-width: 14px 0 14px 22px;
+  border-color: transparent transparent transparent rgba(55, 65, 81, 0.8);
 }
 .video-wrap {
   position: relative;
@@ -276,7 +290,7 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba(0, 0, 0, 0.4);
+  background: none;
   border: none;
   cursor: pointer;
   transition: opacity 0.2s ease;
@@ -286,15 +300,24 @@ body {
 }
 .play-overlay::before {
   content: "";
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  background: rgba(240, 242, 245, 0.92);
+  box-shadow: 0 6px 18px rgba(9, 30, 66, 0.18);
   display: block;
+}
+.play-overlay::after {
+  content: "";
+  position: absolute;
   width: 0;
   height: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-30%, -50%);
   border-style: solid;
-  /* 調整邊框寬度以增大三角形尺寸 */
-  /* 放大播放按鈕三角形尺寸，使其在手機上更明顯 */
-  /* 再次放大三角形尺寸，使播放按鈕更顯眼 */
-  border-width: 36px 0 36px 60px;
-  border-color: transparent transparent transparent #ffffff;
+  border-width: 14px 0 14px 22px;
+  border-color: transparent transparent transparent rgba(55, 65, 81, 0.8);
 }
 /* 播放中隱藏覆蓋按鈕 */
 .video-wrap.video-playing .play-overlay {
@@ -347,9 +370,9 @@ header.header .banner {
 
 /* 主內容容器：限制最大寬度為 480px，適合手機瀏覽 */
 .container {
-  max-width: 480px;
+  max-width: 520px;
   margin: 0 auto;
-  padding: 16px;
+  padding: 24px 24px 40px;
 }
 
 /* 問候卡片：圓角白底陰影，與橫幅微距離 */
@@ -357,8 +380,9 @@ header.header .banner {
   background: #FFFFFF;
   border-radius: 16px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-  padding: 20px;
+  padding: 24px;
   margin-top: -40px;
+  margin-bottom: 28px;
   position: relative;
   z-index: 1;
 }
@@ -375,18 +399,18 @@ header.header .banner {
   font-size: 1rem;
   font-weight: 600;
   text-align: center;
-  margin: 20px 0;
+  margin: 24px 0;
   cursor: default;
 }
 
 /* 水平滾動圖片容器：支持手指拖曳，scroll-snap 對齊 */
 .slides-wrapper {
   display: flex;
-  gap: 16px;
+  gap: 18px;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
   -webkit-overflow-scrolling: touch;
-  margin: 16px 0;
+  margin: 24px 0 28px;
 }
 .slides-wrapper .slide {
   flex: 0 0 80%;
@@ -408,7 +432,7 @@ header.header .banner {
   font-size: 0.9rem;
   /* 使用中性色調的深灰色，使文本不會過於突出 */
   color: #637A91;
-  margin: 8px 0;
+  margin: 16px 0 28px;
 }
 .survey-msg {
   font-size: 0.85rem;
@@ -421,14 +445,15 @@ header.header .banner {
 .videos-section {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 24px;
+  margin: 32px 0;
 }
 .videos-section .video-item {
   position: relative;
   border-radius: 16px;
   overflow: hidden;
   background: #F5F5F5;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.06);
 }
 .videos-section .video-item video {
   width: 100%;
@@ -445,17 +470,31 @@ header.header .banner {
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba(0, 0, 0, 0.4);
+  background: none;
   border: none;
   cursor: pointer;
   z-index: 2;
 }
 .videos-section .play-overlay::before {
   content: "";
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  background: rgba(240, 242, 245, 0.92);
+  box-shadow: 0 6px 18px rgba(9, 30, 66, 0.18);
+  display: block;
+}
+.videos-section .play-overlay::after {
+  content: "";
+  position: absolute;
+  width: 0;
+  height: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-30%, -50%);
   border-style: solid;
-  /* 將播放按鈕尺寸縮小為原來的一半（18px x 30px） */
-  border-width: 18px 0 18px 30px;
-  border-color: transparent transparent transparent #FFFFFF;
+  border-width: 14px 0 14px 22px;
+  border-color: transparent transparent transparent rgba(55, 65, 81, 0.8);
 }
 
 /* 影片標題覆蓋：顯示在影片預覽底部的文字，用於簡要描述影片內容 */
@@ -464,20 +503,19 @@ header.header .banner {
   left: 0;
   right: 0;
   bottom: 0;
-  padding: 8px 12px;
-  font-size: 0.9rem;
+  padding: 12px 16px;
+  font-size: 0.95rem;
   font-weight: 600;
   color: #FFFFFF;
   text-align: center;
-  background: rgba(0, 0, 0, 0.5);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.65) 100%);
   z-index: 3;
-  /* 避免標題覆蓋播放按鈕 */
   pointer-events: none;
 }
 
 /* 服務區塊 */
 .services-wrapper {
-  margin-top: 32px;
+  margin-top: 40px;
   text-align: center;
 }
 .services-title {
@@ -499,7 +537,7 @@ header.header .banner {
 
 /* 推薦朋友區塊 */
 .referral-wrapper {
-  margin-top: 32px;
+  margin-top: 40px;
   text-align: center;
 }
 .referral-img-box {
@@ -924,16 +962,30 @@ button:hover {
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba(0, 0, 0, 0.35);
+  background: none;
   border: none;
   cursor: pointer;
 }
 .video-box .play-overlay::before {
   content: "";
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  background: rgba(240, 242, 245, 0.92);
+  box-shadow: 0 6px 18px rgba(9, 30, 66, 0.18);
+  display: block;
+}
+.video-box .play-overlay::after {
+  content: "";
+  position: absolute;
+  width: 0;
+  height: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-30%, -50%);
   border-style: solid;
-  /* 調整舊版影片元件的播放按鈕尺寸為一半 */
-  border-width: 18px 0 18px 30px;
-  border-color: transparent transparent transparent #ffffff;
+  border-width: 14px 0 14px 22px;
+  border-color: transparent transparent transparent rgba(55, 65, 81, 0.8);
 }
 
 /* Services wrapper and pill title */
@@ -968,4 +1020,79 @@ button:hover {
 }
 .referral-wrapper .share-btn {
   margin-top: 16px;
+}
+
+/* ------------------------------------------------------------------ */
+/* Final layout refinements for centred typography and spacing       */
+/* ------------------------------------------------------------------ */
+main.container {
+  text-align: center;
+  padding: 28px 24px 48px;
+}
+
+main.container > * + * {
+  margin-top: 24px;
+}
+
+.intro-card {
+  padding: 28px 24px;
+  text-align: center;
+  margin-top: -32px;
+  box-shadow: 0 6px 16px rgba(11, 24, 33, 0.08);
+}
+
+.intro-card .greeting-text p {
+  margin-bottom: 12px;
+}
+
+.intro-card .btn {
+  margin-top: 20px;
+}
+
+#slidesContainer {
+  margin: 0 auto;
+}
+
+#slidesContainer p {
+  margin: 0;
+}
+
+.slides-wrapper {
+  margin: 24px 0 28px;
+  padding: 0;
+}
+
+.next-date-text {
+  margin: 16px 0 28px;
+}
+
+.btn {
+  margin: 24px 0;
+}
+
+.videos-section {
+  margin: 32px 0;
+  gap: 24px;
+}
+
+.videos-section .video-item {
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.06);
+}
+
+.videos-section .play-overlay {
+  background: none;
+}
+
+.services-wrapper,
+.referral-wrapper {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.referral-wrapper {
+  padding: 0;
+}
+
+.referral-wrapper .share-btn {
+  margin-top: 24px;
 }

--- a/style.css
+++ b/style.css
@@ -1339,26 +1339,21 @@ body.report-page .design-illustration {
   margin: 0;
 }
 
-body.report-page .videos-section {
+body.report-page .tip-stack {
   width: 100%;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  gap: 24px;
-  padding: 0;
-  background: none;
-  box-shadow: none;
-  color: inherit;
+  align-items: center;
+  gap: 28px;
 }
 
-body.report-page .videos-heading {
-  margin: 0;
-  font-size: 1.2rem;
-  font-weight: 700;
-  color: var(--brand);
+body.report-page .tip-title img {
+  width: 100%;
+  max-width: 520px;
+  display: block;
 }
 
-body.report-page .video-grid {
+body.report-page .tip-videos {
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -1382,6 +1377,18 @@ body.report-page .video-card img {
 body.report-page .video-card:focus-visible {
   outline: 3px solid rgba(0, 190, 214, 0.4);
   outline-offset: 4px;
+}
+
+body.report-page .tip-artwork {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+body.report-page .tip-artwork img {
+  width: 100%;
+  max-width: 520px;
+  display: block;
 }
 
 body.report-page .design-illustration {

--- a/style.css
+++ b/style.css
@@ -9,6 +9,7 @@
   --bg: #F5FAFC;          /* light page background */
   --card: #FFFFFF;        /* card background */
   --text: #0B1821;        /* primary text colour */
+  --muted: #637A91;       /* soft grey body copy */
   --radius: 12px;         /* border radius for cards/buttons */
   --shadow: 0 4px 12px rgba(0, 0, 0, 0.05); /* subtle shadow */
 }
@@ -431,7 +432,7 @@ header.header .banner {
 .next-date-text {
   font-size: 0.9rem;
   /* 使用中性色調的深灰色，使文本不會過於突出 */
-  color: #637A91;
+  color: var(--muted);
   margin: 16px 0 28px;
 }
 .survey-msg {
@@ -876,7 +877,7 @@ button:hover {
   font-size: 0.95rem;
   line-height: 1.5;
   /* 採用較為柔和的深灰色，使問候文案更貼近模板設計 */
-  color: #637A91;
+  color: var(--muted);
 }
 
 /* Primary button shared by records, tip and share */
@@ -929,7 +930,7 @@ button:hover {
 /* 下一次保養日期與問卷訊息：套用一致的深灰色 */
 .next-date-text {
   font-size: 0.9rem;
-  color: #637A91;
+  color: var(--muted);
   margin-bottom: 24px;
 }
 
@@ -1080,7 +1081,46 @@ main.container > * + * {
 }
 
 .videos-section .play-overlay {
-  background: none;
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 56px;
+  height: 56px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 6px 18px rgba(9, 30, 66, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  z-index: 4;
+}
+
+.videos-section .play-overlay::before {
+  content: "";
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 12px 0 12px 18px;
+  border-color: transparent transparent transparent rgba(55, 65, 81, 0.85);
+  transform: translateX(2px);
+}
+
+.videos-section .play-overlay::after {
+  content: none;
+}
+
+.videos-section .play-overlay:focus-visible {
+  outline: 2px solid rgba(0, 190, 214, 0.6);
+  outline-offset: 2px;
+}
+
+.videos-section .play-overlay:hover {
+  transform: scale(1.05);
+  box-shadow: 0 10px 22px rgba(9, 30, 66, 0.2);
 }
 
 .services-wrapper,
@@ -1100,7 +1140,7 @@ main.container > * + * {
 /* 報告頁面最終排版調整：加大間距與容器寬度 */
 body.report-page {
   background: #f7fbfd;
-  color: #5B6E80;
+  color: var(--muted);
 }
 
 body.report-page main.container {
@@ -1125,7 +1165,7 @@ body.report-page .intro-card {
   flex-direction: column;
   gap: 24px;
   text-align: left;
-  color: #5B6E80;
+  color: var(--muted);
 }
 
 body.report-page .greeting-text {
@@ -1209,7 +1249,7 @@ body.report-page .status-row + .status-row {
 
 body.report-page .status-label {
   font-weight: 600;
-  color: #5B6E80;
+  color: var(--muted);
 }
 
 body.report-page .status-value {


### PR DESCRIPTION
## Summary
- repaint both report video poster SVGs so their gradients use the same blue as the header logo
- swap the dark full-frame play overlay for a light grey floating button that leaves video captions legible
- widen the main container and increase section spacing so the layout breathes more comfortably

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c8c1250eb08328b4024cf95d0952bd